### PR TITLE
feat: add settings page, domain validation, and data import/export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,9 @@ ADMIN_NAME=admin
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
 
-EMAIL_FROM=Noreply <noreply@example.com>
-ALLOWED_REGISTER_DOMAINS=example.com
-
-MAILDIR_PATH=./eml
+ALLOWED_DOMAINS=example.com
 
 RESEND_API_KEY=re_xxxxxxxx
 
-# Optional: API key for /api/email/receive endpoint
+MAILDIR_PATH=./eml
 EMAIL_RECEIVE_API_KEY=

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -7,6 +7,7 @@ import AuthPage from './pages/auth/AuthPage';
 import SenderPage from './pages/send/SendPage';
 import SafetyPage from './pages/safety/SafetyPage';
 import ThirdpartyPage from './pages/thirdparty/ThirdpartyPage';
+import SettingsPage from './pages/settings/SettingsPage';
 import { autoRecordLive } from './methods/status';
 
 const PrivateRoute = ({ redirectPath = '/auth' }) => {
@@ -29,6 +30,7 @@ const App = () => {
           <Route path="/send" element={<SenderPage />} />
           <Route path="/safety" element={<SafetyPage />} />
           <Route path="/thirdparty" element={<ThirdpartyPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Route>
         <Route path="/" element={<Navigate to="/inbox" replace />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/client/api/instance.ts
+++ b/client/api/instance.ts
@@ -4,6 +4,8 @@ import { emailRoutes } from "../../shared/modules/email/email.router";
 import { strategyRoutes } from "../../shared/modules/strategy/strategy.router";
 import { safetyRoutes } from "../../shared/modules/safety/safety.router";
 import { thirdpartyRoutes } from "../../shared/modules/thirdparty/thirdparty.router";
+import { settingsRoutes } from "../../shared/modules/settings/settings.router";
+import { accountRoutes } from "../../shared/modules/account/account.router";
 
 type RouteDef = { path: string; request: any; response: any };
 
@@ -37,3 +39,5 @@ export const EmailRouter = buildApiClient(emailRoutes as any, http);
 export const StrategyRouter = buildApiClient(strategyRoutes as any, http);
 export const SafetyRouter = buildApiClient(safetyRoutes as any, http);
 export const ThirdpartyRouter = buildApiClient(thirdpartyRoutes as any, http);
+export const SettingsRouter = buildApiClient(settingsRoutes as any, http);
+export const AccountRouter = buildApiClient(accountRoutes as any, http);

--- a/client/components/header/Menu.tsx
+++ b/client/components/header/Menu.tsx
@@ -19,6 +19,7 @@ export const MenuComp = ({ now }: { now?: string }) => {
         { name: "发送邮件", link: "/send" },
         { name: "安全设置", link: "/safety" },
         { name: "三方邮箱", link: "/thirdparty" },
+        { name: "系统设置", link: "/settings" },
     ];
 
     function handleLogout() {

--- a/client/pages/send/SendPage.tsx
+++ b/client/pages/send/SendPage.tsx
@@ -30,14 +30,6 @@ const SenderPage = () => {
                 <Card className="mb-2">
                     <CardBody className="flex flex-col md:flex-row">
                         <Input
-                            label="发件人"
-                            placeholder="请输入邮箱"
-                            className="md:w-2/5 md:mr-6 my-1"
-                            variant="underlined"
-                            value={from}
-                            onValueChange={setFrom}
-                        />
-                        <Input
                             label="收件人"
                             placeholder="请输入邮箱"
                             className="md:w-2/5 md:mr-6 my-1"
@@ -68,6 +60,13 @@ const SenderPage = () => {
                     </CardBody>
                 </Card>
                 <div className="mx-auto w-3/4 md:mx-0 md:w-100 mt-5 flex flex-col md:flex-row justify-end items-center">
+                    <Input
+                        placeholder="发件邮箱 (仅支持 @noworrytourism.cn)"
+                        className="w-full md:w-80 md:mr-4 my-2"
+                        variant="underlined"
+                        value={from}
+                        onValueChange={setFrom}
+                    />
                     <Button
                         color={justSend ? "default" : "primary"}
                         className="my-2" onClick={sendEmail}

--- a/client/pages/settings/SettingsPage.tsx
+++ b/client/pages/settings/SettingsPage.tsx
@@ -1,0 +1,131 @@
+import { Header } from "../../components/header/Header";
+import { useEffect, useState } from "react";
+import { SettingsRouter, AccountRouter } from "../../api/instance";
+import { SettingsEntry } from "../../../shared/modules/settings/settings.interface";
+import { Button, Card, CardBody, Input } from "@heroui/react";
+import { toast } from "../../methods/notify";
+
+const FIELD_LABELS: Record<string, string> = {
+    resend_api_key: "Resend API Key",
+    allowed_domains: "允许的域名",
+};
+
+export default function SettingsPage() {
+    const [entries, setEntries] = useState<SettingsEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    const fetchSettings = async () => {
+        setLoading(true);
+        SettingsRouter.list({}, (res: any) => {
+            if (res.success && res.data) {
+                setEntries(res.data.entries || []);
+            }
+            setLoading(false);
+        });
+    };
+
+    useEffect(() => {
+        fetchSettings();
+    }, []);
+
+    const handleSave = async () => {
+        setSaving(true);
+        SettingsRouter.save({ entries }, (res: any) => {
+            if (res.success) {
+                toast({ title: "保存成功", color: "primary" });
+            } else {
+                toast({ title: "保存失败", color: "danger" });
+            }
+            setSaving(false);
+        });
+    };
+
+    const updateEntry = (key: string, value: string) => {
+        setEntries(prev => prev.map(e => e.key === key ? { ...e, value } : e));
+    };
+
+    const handleExport = () => {
+        AccountRouter.export({}, (res: any) => {
+            if (!res.success) return toast({ title: "导出失败", color: "danger" });
+            const blob = new Blob([JSON.stringify(res.data, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `cfrs-export-${new Date().toISOString().slice(0, 10)}.json`;
+            a.click();
+            URL.revokeObjectURL(url);
+            toast({ title: "导出成功", color: "primary" });
+        });
+    };
+
+    const handleImport = () => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = ".json";
+        input.onchange = async (e: any) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            try {
+                const text = await file.text();
+                const data = JSON.parse(text);
+                AccountRouter.import({ data }, (res: any) => {
+                    if (res.success) {
+                        const counts = Object.entries(res.data?.imported || {})
+                            .map(([k, v]) => `${k}: ${v}`).join(", ");
+                        toast({ title: `导入成功 (${counts})`, color: "primary" });
+                    } else {
+                        toast({ title: "导入失败", color: "danger" });
+                    }
+                });
+            } catch {
+                toast({ title: "文件格式错误", color: "danger" });
+            }
+        };
+        input.click();
+    };
+
+    return (
+        <div className="max-w-screen">
+            <Header name="系统设置" />
+            <div className="w-full flex flex-col flex-wrap px-[5vw] pt-6">
+                <div className="w-full flex flex-row justify-end items-center mb-4 gap-2">
+                    <Button size="sm" color="primary" variant="bordered" onPress={handleExport}>
+                        导出数据
+                    </Button>
+                    <Button size="sm" color="warning" variant="bordered" onPress={handleImport}>
+                        导入数据
+                    </Button>
+                </div>
+                {loading ? (
+                    <div className="text-center text-gray-400 py-8">加载中...</div>
+                ) : (
+                    <>
+                        <Card>
+                            <CardBody className="flex flex-col gap-4">
+                                {entries.map(e => (
+                                    <div key={e.key} className="flex flex-col gap-1">
+                                        <label className="text-sm font-medium text-gray-600">
+                                            {FIELD_LABELS[e.key] || e.key}
+                                        </label>
+                                        <Input
+                                            size="sm"
+                                            variant="bordered"
+                                            value={e.value}
+                                            onValueChange={(val) => updateEntry(e.key, val)}
+                                        />
+                                    </div>
+                                ))}
+                            </CardBody>
+                        </Card>
+                        <div className="flex items-center gap-4 mt-4">
+                            <Button size="sm" color="primary" isLoading={saving} onPress={handleSave}>
+                                保存设置
+                            </Button>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/client/pages/thirdparty/ThirdpartyPage.tsx
+++ b/client/pages/thirdparty/ThirdpartyPage.tsx
@@ -116,7 +116,7 @@ const ThirdpartyPage = () => {
                                                 className="cursor-pointer"
                                                 onClick={() => { copytext(row.password); toast({ title: "密码已复制", color: "success" }); }}
                                             >
-                                                ******
+                                                ●●●●●●●●
                                             </span>
                                         </Tooltip>
                                         <span
@@ -160,7 +160,7 @@ const ThirdpartyPage = () => {
                                     <Chip color="primary" variant="bordered" className="text-primary shrink-0">
                                         <div className="w-8 text-center">密码</div>
                                     </Chip>
-                                    <span className="text-sm ml-1">******</span>
+                                    <span className="text-sm ml-1">●●●●●●●●</span>
                                     <span
                                         className="text-primary cursor-pointer ml-2 text-xs shrink-0"
                                         onClick={() => { copytext(row.password); toast({ title: "密码已复制", color: "success" }); }}

--- a/server/modules/auth/auth.controller.ts
+++ b/server/modules/auth/auth.controller.ts
@@ -35,7 +35,7 @@ async function login(request: LoginRequest) {
 }
 
 async function config(_request: AuthConfigRequest) {
-    const domains = SettingsService.get("allowed_register_domains");
+    const domains = SettingsService.get("allowed_domains");
     const allowed_domains = domains ? domains.split(",").map(d => d.trim()).filter(Boolean) : [];
     return { allowed_domains };
 }

--- a/server/modules/auth/auth.service.ts
+++ b/server/modules/auth/auth.service.ts
@@ -19,7 +19,7 @@ export async function loginUser(email: string, password: string): Promise<{ toke
 }
 
 function checkAllowedDomain(email: string): string | null {
-    const allowedDomains = SettingsService.get("allowed_register_domains");
+    const allowedDomains = SettingsService.get("allowed_domains");
     if (!allowedDomains) return null;
     const domain = email.split("@")[1]?.toLowerCase();
     if (!domain) return "Invalid email format";

--- a/server/modules/email/email.controller.ts
+++ b/server/modules/email/email.controller.ts
@@ -8,6 +8,7 @@ import {
     EmailRestoreRequest,
 } from "../../../shared/modules/email/email.interface";
 import { emailRoutes } from "../../../shared/modules/email/email.router";
+import { SettingsService } from "../settings/settings.service";
 import { EmailService, sendEmail } from "./email.service";
 import { getIdentifyByVerify } from "../auth/auth.service";
 
@@ -52,6 +53,17 @@ async function send(request: EmailSendRequest) {
     if (!email) throw "Unauthorized";
 
     const { from, to, subject, html } = request.email;
+
+    // Validate from domain against allowed domains
+    const allowedDomains = SettingsService.get("allowed_domains");
+    if (allowedDomains) {
+        const domains = allowedDomains.split(",").map(d => d.trim().toLowerCase()).filter(Boolean);
+        const fromDomain = from.split("@")[1]?.toLowerCase();
+        if (!fromDomain || !domains.includes(fromDomain)) {
+            throw `发件域名不允许，仅支持: ${allowedDomains}`;
+        }
+    }
+
     const result = await sendEmail({ from, to, subject, html });
     if (!result) throw "Failed to send email";
     return {};

--- a/server/modules/email/email.service.ts
+++ b/server/modules/email/email.service.ts
@@ -10,8 +10,6 @@ import fs from "fs";
 const emailRepository: Repository<EmailEntity> = Repository.instance("Email");
 const RESEND_API_URL = "https://api.resend.com/emails";
 
-// ========== Resend API (sending) ==========
-
 interface SendEmailParams {
     from: string;
     to: string;

--- a/server/modules/settings/settings.controller.ts
+++ b/server/modules/settings/settings.controller.ts
@@ -9,7 +9,9 @@ import { requireAdmin } from "../auth/auth.service";
 async function list(request: SettingsListRequest) {
     request = SettingsListRequest.self(request);
     await requireAdmin(request.auth);
-    return SettingsService.getAll();
+    const settings = SettingsService.getAll();
+    const entries = Object.entries(settings).map(([key, value]) => ({ key, value }));
+    return { entries };
 }
 
 async function save(request: SettingsSaveRequest) {

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -7,13 +7,7 @@ const cache = new Map<string, string>();
 
 const SETTING_KEYS: Record<string, string> = {
     "resend_api_key": "RESEND_API_KEY",
-    "email_from": "EMAIL_FROM",
-    "allowed_register_domains": "ALLOWED_REGISTER_DOMAINS",
-    "client_url": "CLIENT_URL",
-    "smtp_host": "SMTP_HOST",
-    "smtp_port": "SMTP_PORT",
-    "smtp_user": "SMTP_USER",
-    "smtp_pass": "SMTP_PASS",
+    "allowed_domains": "ALLOWED_DOMAINS",
 };
 
 export class SettingsService {


### PR DESCRIPTION
## Summary

- **Settings page**: new `/settings` page with config management (Resend API Key, allowed domains) and data import/export
- **Domain validation**: validate sender email domain against `allowed_domains` on email send
- **Rename**: `ALLOWED_REGISTER_DOMAINS` → `ALLOWED_DOMAINS` for clarity (controls both registration and sending)
- **UI tweaks**: move sender email input next to send button, improve password display masking in thirdparty page

## Key Changes

- `server/modules/settings/` — simplified SETTING_KEYS, only keep used keys; fix list response format (return entries array)
- `server/modules/auth/` — rename setting key reference
- `server/modules/email/` — add from domain validation before sending; clean up dead comment
- `client/pages/settings/` — new SettingsPage with config form and import/export buttons
- `client/api/instance.ts` — register SettingsRouter and AccountRouter
- `client/App.tsx` — add `/settings` route
- `client/components/header/Menu.tsx` — add system-setting menu item
- `client/pages/send/SendPage.tsx` — move from field to bottom next to send button
- `client/pages/thirdparty/ThirdpartyPage.tsx` — improve password masking