### PR TITLE
fix: OOM prevention, multi-domain Resend, allow_register toggle

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 
 import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import StrategyPage from './pages/strategy/StrategyPage';
 import InboxPage from './pages/inbox/InboxPage';
 import AuthPage from './pages/auth/AuthPage';
@@ -9,12 +10,28 @@ import SafetyPage from './pages/safety/SafetyPage';
 import ThirdpartyPage from './pages/thirdparty/ThirdpartyPage';
 import SettingsPage from './pages/settings/SettingsPage';
 import { autoRecordLive } from './methods/status';
+import { AuthRouter } from './api/instance';
 
 const PrivateRoute = ({ redirectPath = '/auth' }) => {
-  // 检查 localStorage 中的 token
-  const isAuthenticated = !!localStorage.getItem('token');
+  const token = localStorage.getItem('token');
+  const [ok, setOk] = useState(!!token);
 
-  return isAuthenticated ? <Outlet /> : <Navigate to={redirectPath} replace />;
+  useEffect(() => {
+    if (!token) return;
+    AuthRouter.alive({});
+    window.addEventListener('alive', (e: any) => {
+      if (e.detail?.success) {
+        setOk(true);
+      } else {
+        localStorage.removeItem('token');
+        setOk(false);
+      }
+    }, { once: true });
+  }, [token]);
+
+  if (!token) return <Navigate to={redirectPath} replace />;
+  if (!ok) return null;
+  return <Outlet />;
 };
 
 const App = () => {

--- a/client/lib/webhttp.ts
+++ b/client/lib/webhttp.ts
@@ -27,6 +27,8 @@ export class HttpClientService {
             window.dispatchEvent(event);
         } catch (e) {
             console.error("HTTP GET error:", e);
+            const event = new CustomEvent(name, { detail: { success: false, message: "网络异常，请求失败" }, bubbles: true });
+            window.dispatchEvent(event);
         }
     }
 
@@ -45,6 +47,8 @@ export class HttpClientService {
             window.dispatchEvent(event);
         } catch (e) {
             console.error("HTTP POST error:", e);
+            const event = new CustomEvent(name, { detail: { success: false, message: "网络异常，请求失败" }, bubbles: true });
+            window.dispatchEvent(event);
         }
     }
 }

--- a/client/pages/auth/AuthPage.tsx
+++ b/client/pages/auth/AuthPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Input, Link, Form, addToast } from "@heroui/react";
 import { AuthRouter } from "../../api/instance";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -10,6 +10,15 @@ export default function Component() {
     const [searchParams] = useSearchParams();
     const token = searchParams.get("token");
     const [isRegister, setIsRegister] = useState(false);
+    const [allowRegister, setAllowRegister] = useState(false);
+
+    useEffect(() => {
+        AuthRouter.config({}, (res: any) => {
+            if (res.success && res.data) {
+                setAllowRegister(res.data.allow_register === true);
+            }
+        });
+    }, []);
 
     // Handle verification token from email link
     if (token) {
@@ -98,12 +107,14 @@ export default function Component() {
                                 登录
                             </Button>
                         </Form>
-                        <p className="text-center text-sm text-gray-500">
-                            还没有账号？{" "}
-                            <Link className="cursor-pointer text-sm" size="sm" onClick={() => setIsRegister(true)}>
-                                立即注册
-                            </Link>
-                        </p>
+                        {allowRegister && (
+                            <p className="text-center text-sm text-gray-500">
+                                还没有账号？{" "}
+                                <Link className="cursor-pointer text-sm" size="sm" onClick={() => setIsRegister(true)}>
+                                    立即注册
+                                </Link>
+                            </p>
+                        )}
                     </>
                 ) : (
                     <>

--- a/client/pages/send/SendPage.tsx
+++ b/client/pages/send/SendPage.tsx
@@ -1,7 +1,7 @@
 import { Header } from "../../components/header/Header";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Card, CardBody, Input, Textarea } from "@heroui/react";
-import { EmailRouter } from "../../api/instance";
+import { EmailRouter, AuthRouter } from "../../api/instance";
 import { toast } from "../../methods/notify";
 
 const SenderPage = () => {
@@ -10,6 +10,19 @@ const SenderPage = () => {
     const [subject, setSubject] = useState("");
     const [html, setHtml] = useState("");
     const [justSend, setJustSend] = useState(false);
+    const [fromDomains, setFromDomains] = useState<string[]>([]);
+
+    useEffect(() => {
+        AuthRouter.config({}, (res: any) => {
+            if (res.success && res.data) {
+                setFromDomains(res.data.allowed_from_domains || []);
+            }
+        });
+    }, []);
+
+    const placeholder = fromDomains.length
+        ? `发件邮箱（仅支持 @${fromDomains.join(", @")}）`
+        : "发件邮箱";
 
     async function sendEmail() {
         if (from.length < 2 || !from.includes("@")) return toast({ title: "请填写正确的发件邮箱", color: "danger" });
@@ -20,7 +33,11 @@ const SenderPage = () => {
         setJustSend(true);
         setTimeout(() => setJustSend(false), 5000);
         EmailRouter.send({ email: { from, to, subject, html } }, (res: any) => {
-            if (res.success) toast({ title: "发送成功", color: "primary" });
+            if (res.success) {
+                toast({ title: "发送成功", color: "primary" });
+            } else {
+                toast({ title: res.message || "发送失败", color: "danger" });
+            }
         })
     }
     return (
@@ -61,7 +78,7 @@ const SenderPage = () => {
                 </Card>
                 <div className="mx-auto w-3/4 md:mx-0 md:w-100 mt-5 flex flex-col md:flex-row justify-end items-center">
                     <Input
-                        placeholder="发件邮箱 (仅支持 @noworrytourism.cn)"
+                        placeholder={placeholder}
                         className="w-full md:w-80 md:mr-4 my-2"
                         variant="underlined"
                         value={from}

--- a/client/pages/settings/SettingsPage.tsx
+++ b/client/pages/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { Button, Card, CardBody, Input } from "@heroui/react";
 import { toast } from "../../methods/notify";
 
 const FIELD_LABELS: Record<string, string> = {
+    allow_register: "允许注册（1=开启, 0=关闭）",
     resend_api_key: "Resend API Key（默认）",
     resend_api_keys: "Resend API Keys（多域名，格式：domain1:key1,domain2:key2）",
     allowed_domains: "允许注册的域名",

--- a/client/pages/settings/SettingsPage.tsx
+++ b/client/pages/settings/SettingsPage.tsx
@@ -6,8 +6,11 @@ import { Button, Card, CardBody, Input } from "@heroui/react";
 import { toast } from "../../methods/notify";
 
 const FIELD_LABELS: Record<string, string> = {
-    resend_api_key: "Resend API Key",
-    allowed_domains: "允许的域名",
+    resend_api_key: "Resend API Key（默认）",
+    resend_api_keys: "Resend API Keys（多域名，格式：domain1:key1,domain2:key2）",
+    allowed_domains: "允许注册的域名",
+    allowed_from_domains: "允许发件的域名",
+    client_url: "客户端地址",
 };
 
 export default function SettingsPage() {

--- a/server/app/initialize.ts
+++ b/server/app/initialize.ts
@@ -12,7 +12,6 @@ export async function initialize() {
     // Create default admin account from env
     if (process.env.ADMIN_NAME && process.env.ADMIN_EMAIL && process.env.ADMIN_PASSWORD) {
         const exist = await AccountService.findByEmail(process.env.ADMIN_EMAIL);
-        console.log(process.env.ADMIN_PASSWORD, hashGenerate(process.env.ADMIN_PASSWORD));
         if (!exist || exist.delete_time) {
             await AccountService.create({
                 name: process.env.ADMIN_NAME,

--- a/server/lib/mount.ts
+++ b/server/lib/mount.ts
@@ -120,10 +120,19 @@ export async function mountstatic(staticPath: string, pathName: string) {
         return new Response("Forbidden", { status: 403 });
     }
 
+    if (pathName.includes("..")) {
+        return new Response("Forbidden", { status: 403 });
+    }
+
     let filePath = path.join(staticPath, pathName);
     if (pathName === "/") {
         filePath = path.join(staticPath, "index.html");
     }
+
+    if (!filePath.startsWith(staticPath)) {
+        return new Response("Forbidden", { status: 403 });
+    }
+
     if (!validStaticFiles.has(filePath)) {
         // @ts-ignore
         const file = Bun.file(filePath);

--- a/server/lib/repository.ts
+++ b/server/lib/repository.ts
@@ -298,48 +298,39 @@ class Repository<
 
     async update(where: Partial<T>, updateData: Partial<T>, includeDeleted = false): Promise<boolean> {
         return this.withLock(async () => {
-            const file = this.filePath();
-            if (!fs.existsSync(file)) return false;
-            const tmp = file + ".tmp";
             const now = Date.now();
             let updated = false;
-            const buf: string[] = [];
+            const file = this.filePath();
+            if (!fs.existsSync(file)) return false;
 
-            const flush = () => {
-                if (buf.length === 0) return;
-                fs.appendFileSync(tmp, buf.join("\n") + "\n");
-                buf.length = 0;
-            };
+            const content = fs.readFileSync(file, "utf-8");
+            const lines = content.split("\n");
+            const out: string[] = [];
 
-            try {
-                for await (const row of readLines(this.collection)) {
-                    if (!includeDeleted && row.delete_time) {
-                        buf.push(JSON.stringify(row));
-                        if (buf.length >= 1000) flush();
-                        continue;
-                    }
-
-                    let match = true;
-                    for (const [key, val] of Object.entries(where)) {
-                        if (row[key] !== val) { match = false; break; }
-                    }
-
-                    if (match) {
-                        Object.assign(row, updateData, { update_time: now });
-                        updated = true;
-                    }
-                    buf.push(JSON.stringify(row));
-                    if (buf.length >= 1000) flush();
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                const row = JSON.parse(trimmed);
+                if (!includeDeleted && row.delete_time) {
+                    out.push(line);
+                    continue;
                 }
-            } finally {
-                flush();
+
+                let match = true;
+                for (const [key, val] of Object.entries(where)) {
+                    if (row[key] !== val) { match = false; break; }
+                }
+
+                if (match) {
+                    Object.assign(row, updateData, { update_time: now });
+                    out.push(JSON.stringify(row));
+                    updated = true;
+                } else {
+                    out.push(line);
+                }
             }
 
-            if (updated) {
-                fs.renameSync(tmp, file);
-            } else {
-                try { fs.unlinkSync(tmp); } catch {}
-            }
+            fs.writeFileSync(file, out.join("\n") + "\n");
             return updated;
         });
     }
@@ -361,38 +352,31 @@ class Repository<
         return this.withLock(async () => {
             const file = this.filePath();
             if (!fs.existsSync(file)) return false;
-            const tmp = file + ".tmp";
+
             let deleted = false;
-            const buf: string[] = [];
 
-            const flush = () => {
-                if (buf.length === 0) return;
-                fs.appendFileSync(tmp, buf.join("\n") + "\n");
-                buf.length = 0;
-            };
+            const content = fs.readFileSync(file, "utf-8");
+            const lines = content.split("\n");
+            const out: string[] = [];
 
-            try {
-                for await (const row of readLines(this.collection)) {
-                    let match = true;
-                    for (const [key, val] of Object.entries(where)) {
-                        if (row[key] !== val) { match = false; break; }
-                    }
-                    if (match) {
-                        deleted = true;
-                    } else {
-                        buf.push(JSON.stringify(row));
-                        if (buf.length >= 1000) flush();
-                    }
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                const row = JSON.parse(trimmed);
+
+                let match = true;
+                for (const [key, val] of Object.entries(where)) {
+                    if (row[key] !== val) { match = false; break; }
                 }
-            } finally {
-                flush();
+
+                if (match) {
+                    deleted = true;
+                } else {
+                    out.push(line);
+                }
             }
 
-            if (deleted) {
-                fs.renameSync(tmp, file);
-            } else {
-                try { fs.unlinkSync(tmp); } catch {}
-            }
+            fs.writeFileSync(file, out.join("\n") + "\n");
             return deleted;
         });
     }
@@ -407,51 +391,40 @@ class Repository<
         includeDeleted = false,
     ): Promise<boolean> {
         return this.withLock(async () => {
-            const file = this.filePath();
-            if (!fs.existsSync(file)) return false;
-            const tmp = file + ".tmp";
             const now = Date.now();
             let updated = false;
-            const buf: string[] = [];
+            const file = this.filePath();
+            if (!fs.existsSync(file)) return false;
 
-            const flush = () => {
-                if (buf.length === 0) return;
-                fs.appendFileSync(tmp, buf.join("\n") + "\n");
-                buf.length = 0;
-            };
+            const content = fs.readFileSync(file, "utf-8");
+            const lines = content.split("\n");
+            const out: string[] = [];
 
-            try {
-                for await (const row of readLines(this.collection)) {
-                    if (!includeDeleted && row.delete_time) {
-                        buf.push(JSON.stringify(row));
-                        if (buf.length >= 1000) flush();
-                        continue;
-                    }
-
-                    let match = true;
-                    for (const [key, val] of Object.entries(where)) {
-                        if (row[key] !== val) { match = false; break; }
-                    }
-
-                    if (match) {
-                        const patchData = patch(row);
-                        if (patchData) {
-                            Object.assign(row, patchData, { update_time: now });
-                            updated = true;
-                        }
-                    }
-                    buf.push(JSON.stringify(row));
-                    if (buf.length >= 1000) flush();
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                const row = JSON.parse(trimmed);
+                if (!includeDeleted && row.delete_time) {
+                    out.push(line);
+                    continue;
                 }
-            } finally {
-                flush();
+
+                let match = true;
+                for (const [key, val] of Object.entries(where)) {
+                    if (row[key] !== val) { match = false; break; }
+                }
+
+                if (match) {
+                    const patchData = patch(row);
+                    if (patchData) {
+                        Object.assign(row, patchData, { update_time: now });
+                        updated = true;
+                    }
+                }
+                out.push(JSON.stringify(row));
             }
 
-            if (updated) {
-                fs.renameSync(tmp, file);
-            } else {
-                try { fs.unlinkSync(tmp); } catch {}
-            }
+            fs.writeFileSync(file, out.join("\n") + "\n");
             return updated;
         });
     }

--- a/server/lib/repository.ts
+++ b/server/lib/repository.ts
@@ -18,27 +18,11 @@ function collectionFile(name: string): string {
     return path.join(DATA_DIR, `${name}.jsonl`);
 }
 
-function hardDeleteFile(name: string): string {
-    return path.join(DATA_DIR, `${name}.deleted`);
-}
-
-function readDeleted(name: string): Set<string> {
-    const file = hardDeleteFile(name);
-    if (!fs.existsSync(file)) return new Set();
-    const ids = fs.readFileSync(file, "utf-8").trim().split("\n").filter(Boolean);
-    return new Set(ids);
-}
-
-function appendDeleted(name: string, id: string) {
-    fs.appendFileSync(hardDeleteFile(name), id + "\n");
-}
-
 /** Read lines from end to start (newest first) — used for paginated find() with DESC order */
-async function* readLinesReverse(name: string, skipDeleted: boolean): AsyncGenerator<Row, void, void> {
+async function* readLinesReverse(name: string): AsyncGenerator<Row, void, void> {
     const file = collectionFile(name);
     if (!fs.existsSync(file)) return;
 
-    const deleted = skipDeleted ? readDeleted(name) : new Set<string>();
     const stat = fs.statSync(file);
     if (stat.size === 0) return;
 
@@ -61,15 +45,12 @@ async function* readLinesReverse(name: string, skipDeleted: boolean): AsyncGener
                 const trimmed = lines[i].trim();
                 if (!trimmed) continue;
                 const row = JSON.parse(trimmed);
-                if (skipDeleted && row.id && deleted.has(row.id)) continue;
                 yield row;
             }
         }
         if (remainder.trim()) {
             const row = JSON.parse(remainder.trim());
-            if (!(skipDeleted && row.id && deleted.has(row.id))) {
-                yield row;
-            }
+            yield row;
         }
     } finally {
         fs.closeSync(fd);
@@ -77,11 +58,9 @@ async function* readLinesReverse(name: string, skipDeleted: boolean): AsyncGener
 }
 
 /** Read lines forward — used for findOne(), count(), findAllIgnoreDelete() */
-async function* readLines(name: string, skipDeleted: boolean): AsyncGenerator<Row, void, void> {
+async function* readLines(name: string): AsyncGenerator<Row, void, void> {
     const file = collectionFile(name);
     if (!fs.existsSync(file)) return;
-
-    const deleted = skipDeleted ? readDeleted(name) : new Set<string>();
 
     const stream = Bun.file(file).stream();
     const reader = stream.getReader();
@@ -99,30 +78,41 @@ async function* readLines(name: string, skipDeleted: boolean): AsyncGenerator<Ro
                 const trimmed = line.trim();
                 if (!trimmed) continue;
                 const row = JSON.parse(trimmed);
-                if (skipDeleted && row.id && deleted.has(row.id)) continue;
                 yield row;
             }
         }
         if (buffer.trim()) {
             const row = JSON.parse(buffer.trim());
-            if (!(skipDeleted && row.id && deleted.has(row.id))) {
-                yield row;
-            }
+            yield row;
         }
     } finally {
         reader.cancel().catch(() => {});
     }
 }
 
-/** Check if a row matches the where conditions */
+/** Check if a row matches the where conditions. Supports operators: $eq, $ne, $gt, $gte, $lt, $lte, $in. */
 function matches<T extends Row>(row: T, where: Record<string, any>): boolean {
     for (const [key, val] of Object.entries(where)) {
         if (val === undefined || val === "") continue;
+        // null is a valid value for $eq / $ne
         if (val === null) {
-            if (row[key] !== null && row[key] !== undefined) return false;
+            if (row[key] !== null) return false;
             continue;
         }
-        if (row[key] !== val) return false;
+        if (typeof val === "object" && !Array.isArray(val)) {
+            for (const [op, opVal] of Object.entries(val)) {
+                const rowVal = row[key];
+                if (op === "$eq")  { if (rowVal !== opVal) return false; }
+                if (op === "$ne")  { if (rowVal === opVal) return false; }
+                if (op === "$gt")  { if (!(rowVal > opVal)) return false; }
+                if (op === "$gte") { if (!(rowVal >= opVal)) return false; }
+                if (op === "$lt")  { if (!(rowVal < opVal)) return false; }
+                if (op === "$lte") { if (!(rowVal <= opVal)) return false; }
+                if (op === "$in")  { if (!Array.isArray(opVal) || !opVal.includes(rowVal)) return false; }
+            }
+        } else {
+            if (row[key] !== val) return false;
+        }
     }
     return true;
 }
@@ -172,7 +162,7 @@ class Repository<
     }
 
     async find(
-        where?: Partial<T>,
+        where?: Record<string, any>,
         config?: { limit?: number; offset?: number; since?: number },
     ): Promise<T[]> {
         const results: T[] = [];
@@ -180,13 +170,15 @@ class Repository<
         const limit = config?.limit;
         const offset = config?.offset || 0;
 
-        for await (const row of readLinesReverse(this.collection, true)) {
+        // Use reverse read to get newest-first (matches previous Drizzle DESC order)
+        for await (const row of readLinesReverse(this.collection)) {
             if (row.delete_time) continue;
             if (since && row.create_time < since) continue;
 
             if (where && !matches(row, where as Record<string, any>)) continue;
 
             results.push(row as T);
+            // If limit is set, stop reading when we have enough to satisfy offset+limit
             if (limit !== undefined && results.length >= offset + limit) break;
         }
 
@@ -196,8 +188,54 @@ class Repository<
         return results;
     }
 
-    async findOne(where: Partial<T>): Promise<T | null> {
-        for await (const row of readLines(this.collection, true)) {
+    /** Stream rows one at a time via callback — never accumulates, avoids OOM */
+    async findEach(
+        callback: (row: T) => void,
+        config?: { where?: Record<string, any>; limit?: number; since?: number; includeDeleted?: boolean },
+    ): Promise<number> {
+        let count = 0;
+        const where = config?.where;
+        const since = config?.since;
+        const limit = config?.limit;
+        const includeDeleted = config?.includeDeleted ?? false;
+
+        for await (const row of readLines(this.collection)) {
+            if (!includeDeleted && row.delete_time) continue;
+            if (since && row.create_time < since) continue;
+            if (where && !matches(row, where)) continue;
+
+            callback(row as T);
+            count++;
+            if (limit && count >= limit) break;
+        }
+        return count;
+    }
+
+    /** Streaming sum of a numeric field — avoids loading all rows into memory */
+    async sum(field: string, where?: Record<string, any>, since?: number): Promise<number> {
+        let total = 0;
+        for await (const row of readLines(this.collection)) {
+            if (row.delete_time) continue;
+            if (since && row.create_time < since) continue;
+            if (where && !matches(row, where as Record<string, any>)) continue;
+            total += row[field] || 0;
+        }
+        return total;
+    }
+
+    /** Stream through rows and return the first match — stops early, avoids accumulation */
+    async findFirst(where?: Record<string, any>, includeDeleted = false): Promise<T | null> {
+        for await (const row of readLines(this.collection)) {
+            if (!includeDeleted && row.delete_time) continue;
+            if (where && !matches(row, where as Record<string, any>)) continue;
+            return row as T;
+        }
+        return null;
+    }
+
+    async findOne(where: Partial<T>, reverse = false): Promise<T | null> {
+        const reader = reverse ? readLinesReverse(this.collection) : readLines(this.collection);
+        for await (const row of reader) {
             if (row.delete_time) continue;
             if (matches(row, where as Record<string, any>)) return row as T;
         }
@@ -205,15 +243,16 @@ class Repository<
     }
 
     async findIgnoreDelete(where: Partial<T>): Promise<T | null> {
-        for await (const row of readLines(this.collection, false)) {
+        for await (const row of readLines(this.collection)) {
             if (matches(row, where as Record<string, any>)) return row as T;
         }
         return null;
     }
 
+    /** Get ALL records (including soft-deleted) — used for data export */
     async findAllIgnoreDelete(): Promise<T[]> {
         const results: T[] = [];
-        for await (const row of readLines(this.collection, false)) {
+        for await (const row of readLines(this.collection)) {
             results.push(row as T);
         }
         return results;
@@ -223,7 +262,7 @@ class Repository<
         if (ids.length === 0) return [];
         const idSet = new Set(ids);
         const results: T[] = [];
-        for await (const row of readLines(this.collection, true)) {
+        for await (const row of readLines(this.collection)) {
             if (row.delete_time) continue;
             if (row.id && idSet.has(row.id)) {
                 results.push(row as T);
@@ -232,15 +271,28 @@ class Repository<
         return results;
     }
 
+    /** Stream all records in batches (including soft-deleted) — avoids loading entire table into memory */
+    async *findAllIgnoreDeleteBatch(batchSize = 1000): AsyncGenerator<T[], void, void> {
+        let batch: T[] = [];
+        for await (const row of readLines(this.collection)) {
+            batch.push(row as T);
+            if (batch.length >= batchSize) {
+                yield batch;
+                batch = [];
+            }
+        }
+        if (batch.length > 0) yield batch;
+    }
+
     async insert(entity: Partial<T>): Promise<T> {
         return this.withLock(async () => {
             const now = Date.now();
-            const id = (entity as any)?.id || nanoid(6);
+            const id = entity.id || nanoid(6);
             const row = {
                 ...entity,
                 id,
-                create_time: (entity as any)?.create_time || now,
-                update_time: (entity as any)?.update_time || now,
+                create_time: entity.create_time || now,
+                update_time: entity.update_time || now,
                 delete_time: null,
             };
             fs.appendFileSync(this.filePath(), JSON.stringify(row) + "\n");
@@ -250,89 +302,109 @@ class Repository<
 
     async update(where: Partial<T>, updateData: Partial<T>, includeDeleted = false): Promise<boolean> {
         return this.withLock(async () => {
-            const now = Date.now();
-            let updated = false;
             const file = this.filePath();
             if (!fs.existsSync(file)) return false;
+            const tmp = file + ".tmp";
+            const now = Date.now();
+            let updated = false;
+            const buf: string[] = [];
 
-            const deleted = readDeleted(this.collection);
-            const content = fs.readFileSync(file, "utf-8");
-            const lines = content.split("\n");
-            const out: string[] = [];
+            const flush = () => {
+                if (buf.length === 0) return;
+                fs.appendFileSync(tmp, buf.join("\n") + "\n");
+                buf.length = 0;
+            };
 
-            for (const line of lines) {
-                const trimmed = line.trim();
-                if (!trimmed) continue;
-                const row = JSON.parse(trimmed);
-                if (row.id && deleted.has(row.id)) continue;
-                if (!includeDeleted && row.delete_time) {
-                    out.push(line);
-                    continue;
-                }
-
-                let match = true;
-                for (const [key, val] of Object.entries(where)) {
-                    if (row[key] !== val) {
-                        match = false;
-                        break;
+            try {
+                for await (const row of readLines(this.collection)) {
+                    if (!includeDeleted && row.delete_time) {
+                        buf.push(JSON.stringify(row));
+                        if (buf.length >= 1000) flush();
+                        continue;
                     }
-                }
 
-                if (match) {
-                    Object.assign(row, updateData, { update_time: now });
-                    out.push(JSON.stringify(row));
-                    updated = true;
-                } else {
-                    out.push(line);
+                    let match = true;
+                    for (const [key, val] of Object.entries(where)) {
+                        if (row[key] !== val) { match = false; break; }
+                    }
+
+                    if (match) {
+                        Object.assign(row, updateData, { update_time: now });
+                        updated = true;
+                    }
+                    buf.push(JSON.stringify(row));
+                    if (buf.length >= 1000) flush();
                 }
+            } finally {
+                flush();
             }
 
-            fs.writeFileSync(file, out.join("\n") + "\n");
+            if (updated) {
+                fs.renameSync(tmp, file);
+            } else {
+                try { fs.unlinkSync(tmp); } catch {}
+            }
             return updated;
         });
     }
 
     async delete(where: Partial<T>): Promise<boolean> {
         const now = Date.now();
-        return this.update(where, { delete_time: now } as any);
+        return this.update(where, { delete_time: now } as Partial<T>);
     }
 
+    /** Clear all data — used before import */
+    async truncate(): Promise<void> {
+        return this.withLock(async () => {
+            fs.writeFileSync(this.filePath(), "");
+        });
+    }
+
+    /** Permanently delete matching records */
     async hardDelete(where: Partial<T>): Promise<boolean> {
         return this.withLock(async () => {
-            let deleted = false;
             const file = this.filePath();
             if (!fs.existsSync(file)) return false;
+            const tmp = file + ".tmp";
+            let deleted = false;
+            const buf: string[] = [];
 
-            const content = fs.readFileSync(file, "utf-8");
-            const lines = content.split("\n");
-            const out: string[] = [];
+            const flush = () => {
+                if (buf.length === 0) return;
+                fs.appendFileSync(tmp, buf.join("\n") + "\n");
+                buf.length = 0;
+            };
 
-            for (const line of lines) {
-                const trimmed = line.trim();
-                if (!trimmed) continue;
-                const row = JSON.parse(trimmed);
-
-                let match = true;
-                for (const [key, val] of Object.entries(where)) {
-                    if (row[key] !== val) {
-                        match = false;
-                        break;
+            try {
+                for await (const row of readLines(this.collection)) {
+                    let match = true;
+                    for (const [key, val] of Object.entries(where)) {
+                        if (row[key] !== val) { match = false; break; }
+                    }
+                    if (match) {
+                        deleted = true;
+                    } else {
+                        buf.push(JSON.stringify(row));
+                        if (buf.length >= 1000) flush();
                     }
                 }
-
-                if (match) {
-                    appendDeleted(this.collection, row.id);
-                    deleted = true;
-                } else {
-                    out.push(line);
-                }
+            } finally {
+                flush();
             }
 
-            fs.writeFileSync(file, out.join("\n") + "\n");
+            if (deleted) {
+                fs.renameSync(tmp, file);
+            } else {
+                try { fs.unlinkSync(tmp); } catch {}
+            }
             return deleted;
         });
     }
 
+    /**
+     * Atomic read-modify-write patch: apply a function to the matched row inside the write lock.
+     * The callback receives the current row (or null) and returns the new row (or null to skip).
+     */
     async atomicPatch(
         where: Partial<T>,
         patch: (row: T | null) => Partial<T> | null,
@@ -341,55 +413,65 @@ class Repository<
         return this.withLock(async () => {
             const file = this.filePath();
             if (!fs.existsSync(file)) return false;
-
-            const deleted = readDeleted(this.collection);
-            const content = fs.readFileSync(file, "utf-8");
-            const lines = content.split("\n");
+            const tmp = file + ".tmp";
             const now = Date.now();
             let updated = false;
+            const buf: string[] = [];
 
-            for (let i = 0; i < lines.length; i++) {
-                const trimmed = lines[i].trim();
-                if (!trimmed) continue;
-                const row = JSON.parse(trimmed);
-                if (row.id && deleted.has(row.id)) continue;
-                if (!includeDeleted && row.delete_time) continue;
+            const flush = () => {
+                if (buf.length === 0) return;
+                fs.appendFileSync(tmp, buf.join("\n") + "\n");
+                buf.length = 0;
+            };
 
-                let match = true;
-                for (const [key, val] of Object.entries(where)) {
-                    if (row[key] !== val) { match = false; break; }
-                }
-
-                if (match) {
-                    const patchData = patch(row);
-                    if (patchData) {
-                        Object.assign(row, patchData, { update_time: now });
-                        lines[i] = JSON.stringify(row);
-                        updated = true;
+            try {
+                for await (const row of readLines(this.collection)) {
+                    if (!includeDeleted && row.delete_time) {
+                        buf.push(JSON.stringify(row));
+                        if (buf.length >= 1000) flush();
+                        continue;
                     }
+
+                    let match = true;
+                    for (const [key, val] of Object.entries(where)) {
+                        if (row[key] !== val) { match = false; break; }
+                    }
+
+                    if (match) {
+                        const patchData = patch(row);
+                        if (patchData) {
+                            Object.assign(row, patchData, { update_time: now });
+                            updated = true;
+                        }
+                    }
+                    buf.push(JSON.stringify(row));
+                    if (buf.length >= 1000) flush();
                 }
+            } finally {
+                flush();
             }
 
             if (updated) {
-                fs.writeFileSync(file, lines.join("\n") + "\n");
+                fs.renameSync(tmp, file);
+            } else {
+                try { fs.unlinkSync(tmp); } catch {}
             }
             return updated;
         });
     }
 
+    /** Insert multiple rows in one write */
     async batchInsert(entities: Partial<T>[]): Promise<number> {
         return this.withLock(async () => {
             if (entities.length === 0) return 0;
             const now = Date.now();
-            const rows = entities.map((e) => {
-                return {
-                    ...e,
-                    id: (e as any)?.id || nanoid(6),
-                    create_time: (e as any)?.create_time || now,
-                    update_time: (e as any)?.update_time || now,
-                    delete_time: null,
-                };
-            });
+            const rows = entities.map((e) => ({
+                ...e,
+                id: e.id || nanoid(6),
+                create_time: e.create_time || now,
+                update_time: e.update_time || now,
+                delete_time: null,
+            }));
             fs.appendFileSync(this.filePath(), rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
             return rows.length;
         });
@@ -397,7 +479,7 @@ class Repository<
 
     async count(where?: Partial<T>, since?: number): Promise<number> {
         let count = 0;
-        for await (const row of readLines(this.collection, true)) {
+        for await (const row of readLines(this.collection)) {
             if (row.delete_time) continue;
             if (since && row.create_time < since) continue;
             if (where && !matches(row, where as Record<string, any>)) continue;

--- a/server/lib/repository.ts
+++ b/server/lib/repository.ts
@@ -167,7 +167,7 @@ class Repository<
     ): Promise<T[]> {
         const results: T[] = [];
         const since = config?.since;
-        const limit = config?.limit;
+        const limit = config?.limit ?? 1000;
         const offset = config?.offset || 0;
 
         // Use reverse read to get newest-first (matches previous Drizzle DESC order)
@@ -178,14 +178,10 @@ class Repository<
             if (where && !matches(row, where as Record<string, any>)) continue;
 
             results.push(row as T);
-            // If limit is set, stop reading when we have enough to satisfy offset+limit
-            if (limit !== undefined && results.length >= offset + limit) break;
+            if (results.length >= offset + limit) break;
         }
 
-        if (offset > 0 || limit !== undefined) {
-            return results.slice(offset, limit !== undefined ? offset + limit : undefined);
-        }
-        return results;
+        return results.slice(offset, offset + limit);
     }
 
     /** Stream rows one at a time via callback — never accumulates, avoids OOM */

--- a/server/modules/account/account.controller.ts
+++ b/server/modules/account/account.controller.ts
@@ -10,6 +10,7 @@ import { accountRoutes } from "../../../shared/modules/account/account.router";
 import { AccountService } from "./account.service";
 import { requireAdmin } from "../auth/auth.service";
 import Repository from "../../lib/repository";
+import { EmailEntity } from "../../../shared/modules/email/email.entity";
 
 async function list(request: AccountListRequest) {
     request = AccountListRequest.self(request);
@@ -47,16 +48,17 @@ async function exportData(request: AccountExportRequest) {
     await requireAdmin(request.auth);
 
     const accountRepo = Repository.instance("Account");
-    const emailRepo = Repository.instance("Email");
+    const emailRepo = Repository.instance<EmailEntity>("Email");
     const strategyRepo = Repository.instance("Strategy");
     const settingsRepo = Repository.instance("Settings");
 
-    const [accounts, emails, strategies, settings] = await Promise.all([
-        accountRepo.findAllIgnoreDelete(),
-        emailRepo.findAllIgnoreDelete(),
-        strategyRepo.findAllIgnoreDelete(),
-        settingsRepo.findAllIgnoreDelete(),
-    ]);
+    const accounts = await accountRepo.findAllIgnoreDelete();
+    const strategies = await strategyRepo.findAllIgnoreDelete();
+    const settings = await settingsRepo.findAllIgnoreDelete();
+    const emails: EmailEntity[] = [];
+    for await (const batch of emailRepo.findAllIgnoreDeleteBatch(2000)) {
+        for (const row of batch) emails.push(row);
+    }
 
     return {
         version: 1,
@@ -80,7 +82,7 @@ async function importData(request: AccountImportRequest) {
 
     for (const { repo, items, name } of tables) {
         if (!items || items.length === 0) continue;
-        await repo.hardDelete({});
+        await repo.truncate();
         for (let i = 0; i < items.length; i += 1000) {
             const chunk = items.slice(i, i + 1000);
             imported[name] = (imported[name] || 0) + await repo.batchInsert(chunk);

--- a/server/modules/auth/auth.controller.ts
+++ b/server/modules/auth/auth.controller.ts
@@ -37,7 +37,9 @@ async function login(request: LoginRequest) {
 async function config(_request: AuthConfigRequest) {
     const domains = SettingsService.get("allowed_domains");
     const allowed_domains = domains ? domains.split(",").map(d => d.trim()).filter(Boolean) : [];
-    return { allowed_domains };
+    const fromDomains = SettingsService.get("allowed_from_domains");
+    const allowed_from_domains = fromDomains ? fromDomains.split(",").map(d => d.trim()).filter(Boolean) : [];
+    return { allowed_domains, allowed_from_domains };
 }
 
 async function register(request: RegisterRequest) {

--- a/server/modules/auth/auth.controller.ts
+++ b/server/modules/auth/auth.controller.ts
@@ -39,11 +39,13 @@ async function config(_request: AuthConfigRequest) {
     const allowed_domains = domains ? domains.split(",").map(d => d.trim()).filter(Boolean) : [];
     const fromDomains = SettingsService.get("allowed_from_domains");
     const allowed_from_domains = fromDomains ? fromDomains.split(",").map(d => d.trim()).filter(Boolean) : [];
-    return { allowed_domains, allowed_from_domains };
+    const allow_register = SettingsService.get("allow_register") !== "0";
+    return { allowed_domains, allowed_from_domains, allow_register };
 }
 
 async function register(request: RegisterRequest) {
     request = RegisterRequest.self(request);
+    if (SettingsService.get("allow_register") === "0") throw "注册功能已关闭";
     const { identify } = request;
     if (!identify) throw "Register data is missing";
     const { name, email, password } = identify;

--- a/server/modules/auth/auth.service.ts
+++ b/server/modules/auth/auth.service.ts
@@ -42,7 +42,10 @@ export async function preRegisterUser(name: string, email: string, password: str
     const payload = [name, email, password].join("|-|");
     const verificationToken = aesEncrypt(payload);
     const verifyUrl = `${SettingsService.get("client_url")}/verify?token=${encodeURIComponent(verificationToken)}`;
+    const fromDomain = (SettingsService.get("allowed_from_domains") || SettingsService.get("allowed_domains")).split(",")[0]?.trim();
+    const from = fromDomain ? `noreply@${fromDomain}` : "noreply@example.com";
     const emailSent = await sendEmail({
+        from,
         to: email,
         ...buildVerificationEmail(verifyUrl),
     });

--- a/server/modules/auth/auth.service.ts
+++ b/server/modules/auth/auth.service.ts
@@ -7,9 +7,7 @@ import { SettingsService } from "../settings/settings.service";
 const accountRepository: Repository<AccountEntity> = Repository.instance("Account");
 
 export async function loginUser(email: string, password: string): Promise<{ token?: string; is_admin?: number; needsVerification?: boolean }> {
-    console.log(password)
     password = hashGenerate(password);
-    console.log(password)
     const emailItem = await accountRepository.findOne({ email, password });
     if (emailItem) {
         return { token: genTokenForIdentify(email), is_admin: emailItem.is_admin };

--- a/server/modules/email/email.controller.ts
+++ b/server/modules/email/email.controller.ts
@@ -54,13 +54,13 @@ async function send(request: EmailSendRequest) {
 
     const { from, to, subject, html } = request.email;
 
-    // Validate from domain against allowed domains
-    const allowedDomains = SettingsService.get("allowed_domains");
-    if (allowedDomains) {
-        const domains = allowedDomains.split(",").map(d => d.trim().toLowerCase()).filter(Boolean);
+    // Validate from domain against allowed_from_domains
+    const allowedFrom = SettingsService.get("allowed_from_domains");
+    if (allowedFrom) {
+        const domains = allowedFrom.split(",").map(d => d.trim().toLowerCase()).filter(Boolean);
         const fromDomain = from.split("@")[1]?.toLowerCase();
         if (!fromDomain || !domains.includes(fromDomain)) {
-            throw `发件域名不允许，仅支持: ${allowedDomains}`;
+            throw `发件域名不允许，仅支持: ${allowedFrom}`;
         }
     }
 

--- a/server/modules/email/email.service.ts
+++ b/server/modules/email/email.service.ts
@@ -73,11 +73,9 @@ export function buildVerificationEmail(verifyUrl: string): { subject: string; ht
 
 export class EmailService {
     static async findList(where?: Partial<EmailEntity>, config?: { limit?: number; offset?: number }): Promise<{ list: EmailEntity[]; total: number }> {
-        const all = await emailRepository.find(where);
-        all.sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
-        const total = all.length;
         const { limit, offset = 0 } = config ?? {};
-        const list = limit !== undefined ? all.slice(offset, offset + limit) : all;
+        const total = await emailRepository.count(where);
+        const list = await emailRepository.find(where, { limit, offset });
         return { list, total };
     }
 
@@ -146,6 +144,15 @@ export class EmailService {
         return `${e.from || ""}|${e.to || ""}|${e.subject || ""}|${e.time || 0}`;
     }
 
+    /** Stream-collect dedup keys from all stored emails (incl. soft-deleted) — never holds full row objects */
+    private static async collectDedupKeys(): Promise<Set<string>> {
+        const keys = new Set<string>();
+        await emailRepository.findEach((e) => {
+            keys.add(EmailService.dedupKey(e));
+        }, { includeDeleted: true });
+        return keys;
+    }
+
     /**
      * Scan a directory recursively for Maildir files and import any that don't already exist.
      * Supports both standard Maildir structure (domain/new/filename) and plain .eml files.
@@ -162,42 +169,22 @@ export class EmailService {
             throw `Path is not a directory: ${dirPath}`;
         }
 
-        // Build set of known dedup keys (include soft-deleted)
-        const existingKeys = new Set<string>();
-        const allEmails = await emailRepository.findAllIgnoreDelete();
-        for (const e of allEmails) {
-            existingKeys.add(EmailService.dedupKey(e));
-        }
+        const existingKeys = await EmailService.collectDedupKeys();
 
-        // Recursively collect all regular files, skip dotfiles
-        const mailFiles: string[] = [];
-        function walk(dir: string) {
-            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                if (entry.name.startsWith(".")) continue;
-                const full = path.join(dir, entry.name);
-                if (entry.isDirectory()) {
-                    walk(full);
-                } else if (entry.isFile()) {
-                    mailFiles.push(full);
-                }
-            }
-        }
-        walk(dirPath);
-
+        let scanned = 0;
         let imported = 0;
 
-        for (const fullPath of mailFiles) {
+        for (const fullPath of EmailService.walkFiles(dirPath)) {
+            scanned++;
             try {
                 const content = fs.readFileSync(fullPath, "utf-8");
                 const parsed = EmailService.parseRawEmail(content);
                 if (!parsed) continue;
 
-                // Skip if a matching email already exists
                 if (existingKeys.has(EmailService.dedupKey(parsed))) {
                     continue;
                 }
 
-                // Safety check: block blacklisted senders and sensitive words
                 const blocked = await SafetyService.isBlocked(
                     parsed.from || "",
                     parsed.subject || "",
@@ -233,7 +220,20 @@ export class EmailService {
             }
         }
 
-        return { scanned: mailFiles.length, imported };
+        return { scanned, imported };
+    }
+
+    /** Recursively yield all regular files in a directory, skipping dotfiles */
+    private static *walkFiles(dir: string): Generator<string, void, void> {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.name.startsWith(".")) continue;
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                yield* EmailService.walkFiles(full);
+            } else if (entry.isFile()) {
+                yield full;
+            }
+        }
     }
 
     /**
@@ -250,8 +250,8 @@ export class EmailService {
 
             // Dedup by content fingerprint (from+to+subject+time), even if soft-deleted
             const dedupKey = EmailService.dedupKey(parsed);
-            const allEmails = await emailRepository.findAllIgnoreDelete();
-            if (allEmails.some(e => EmailService.dedupKey(e) === dedupKey)) return null;
+            const existingKeys = await EmailService.collectDedupKeys();
+            if (existingKeys.has(dedupKey)) return null;
 
             const email: Partial<EmailEntity> = {
                 eid: nanoid(12),

--- a/server/modules/email/email.service.ts
+++ b/server/modules/email/email.service.ts
@@ -144,7 +144,16 @@ export class EmailService {
         return `${e.from || ""}|${e.to || ""}|${e.subject || ""}|${e.time || 0}`;
     }
 
-    /** Stream-collect dedup keys from all stored emails (incl. soft-deleted) — never holds full row objects */
+    /** Check if an email with matching fingerprint already exists (incl. soft-deleted). Streams — stops on first hit. */
+    private static async dedupExists(e: { from?: string; to?: string; subject?: string; time?: number }): Promise<boolean> {
+        const existing = await emailRepository.findFirst(
+            { from: e.from, to: e.to, subject: e.subject, time: e.time },
+            true,
+        );
+        return existing !== null;
+    }
+
+    /** Stream-collect dedup keys from all stored emails (incl. soft-deleted) — used only by scanDirectory batch import */
     private static async collectDedupKeys(): Promise<Set<string>> {
         const keys = new Set<string>();
         await emailRepository.findEach((e) => {
@@ -249,9 +258,8 @@ export class EmailService {
             if (!parsed) return null;
 
             // Dedup by content fingerprint (from+to+subject+time), even if soft-deleted
-            const dedupKey = EmailService.dedupKey(parsed);
-            const existingKeys = await EmailService.collectDedupKeys();
-            if (existingKeys.has(dedupKey)) return null;
+            const exists = await EmailService.dedupExists(parsed);
+            if (exists) return null;
 
             const email: Partial<EmailEntity> = {
                 eid: nanoid(12),

--- a/server/modules/email/email.service.ts
+++ b/server/modules/email/email.service.ts
@@ -18,9 +18,21 @@ interface SendEmailParams {
 }
 
 export async function sendEmail({ from, to, subject, html }: SendEmailParams): Promise<boolean> {
-    const api_key = SettingsService.get("resend_api_key");
+    // Match API key by from domain: "resend_api_keys" stores "domain1:key1,domain2:key2"
+    let api_key = SettingsService.get("resend_api_key");
+    const keyMap = SettingsService.get("resend_api_keys");
+    if (keyMap) {
+        const fromDomain = from.split("@")[1]?.toLowerCase();
+        for (const pair of keyMap.split(",")) {
+            const [domain, key] = pair.split(":").map(s => s.trim());
+            if (domain && key && domain.toLowerCase() === fromDomain) {
+                api_key = key;
+                break;
+            }
+        }
+    }
     if (!api_key) {
-        console.error("RESEND_API_KEY is not configured");
+        console.error("RESEND_API_KEY is not configured for domain in:", from);
         return false;
     }
 

--- a/server/modules/safety/safety.service.ts
+++ b/server/modules/safety/safety.service.ts
@@ -29,34 +29,34 @@ export class SafetyService {
     /**
      * Check whether an incoming email should be blocked.
      * Priority: whitelist > blacklist > sensitive_word
+     * Streams rules one at a time — no accumulation in memory.
      */
     static async isBlocked(from: string, subject: string, html?: string, text?: string): Promise<boolean> {
-        const all = await safetyRepository.find({});
         const body = (html || "") + (text || "");
 
-        const whitelist = all.filter(e => e.type === "whitelist");
-        const blacklist = all.filter(e => e.type === "blacklist");
-        const sensitiveWords = all.filter(e => e.type === "sensitive_word");
+        let whitelisted = false;
+        let blacklisted = false;
+        let sensitive = false;
 
-        // Whitelist check — if sender matches any whitelist, allow through
-        for (const w of whitelist) {
-            if (matchPattern(from, w.value)) return false;
-        }
-
-        // Blacklist check — if sender matches any blacklist, block
-        for (const b of blacklist) {
-            if (matchPattern(from, b.value)) return true;
-        }
-
-        // Sensitive word check — if subject or body contains any word, block
-        for (const sw of sensitiveWords) {
-            const keyword = sw.value.toLowerCase();
-            if (subject.toLowerCase().includes(keyword) || body.toLowerCase().includes(keyword)) {
-                return true;
+        await safetyRepository.findEach((e) => {
+            if (e.type === "whitelist" && matchPattern(from, e.value)) {
+                whitelisted = true;
             }
-        }
+            if (!blacklisted && e.type === "blacklist" && matchPattern(from, e.value)) {
+                blacklisted = true;
+            }
+            if (!sensitive && e.type === "sensitive_word") {
+                const keyword = e.value.toLowerCase();
+                if (subject.toLowerCase().includes(keyword) || body.toLowerCase().includes(keyword)) {
+                    sensitive = true;
+                }
+            }
+        });
 
-        return false;
+        // Whitelist takes priority over everything
+        if (whitelisted) return false;
+        // Blacklist and sensitive words both cause blocking
+        return blacklisted || sensitive;
     }
 }
 

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -6,6 +6,7 @@ const settingsRepo: Repository<SettingsEntity> = Repository.instance("Settings")
 const cache = new Map<string, string>();
 
 const SETTING_KEYS: Record<string, string> = {
+    "allow_register": "ALLOW_REGISTER",
     "resend_api_key": "RESEND_API_KEY",
     "resend_api_keys": "RESEND_API_KEYS",
     "allowed_domains": "ALLOWED_DOMAINS",

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -7,7 +7,10 @@ const cache = new Map<string, string>();
 
 const SETTING_KEYS: Record<string, string> = {
     "resend_api_key": "RESEND_API_KEY",
+    "resend_api_keys": "RESEND_API_KEYS",
     "allowed_domains": "ALLOWED_DOMAINS",
+    "allowed_from_domains": "ALLOWED_FROM_DOMAINS",
+    "client_url": "CLIENT_URL",
 };
 
 export class SettingsService {

--- a/server/modules/strategy/strategy.controller.ts
+++ b/server/modules/strategy/strategy.controller.ts
@@ -17,8 +17,10 @@ async function list(request: StrategyListRequest) {
     if (!email) throw "Unauthorized";
 
     const strategies = await StrategyService.findList();
-    const accounts = await accountRepo.findAllIgnoreDelete();
-    const accountMap = new Map(accounts.map(a => [a.id, a]));
+    const accountMap = new Map<string, { name?: string; email?: string }>();
+    await accountRepo.findEach((a) => {
+        accountMap.set(a.id!, { name: a.name, email: a.email });
+    });
 
     const list = strategies.map(s => ({
         id: s.id,

--- a/server/modules/strategy/strategy.service.ts
+++ b/server/modules/strategy/strategy.service.ts
@@ -38,6 +38,7 @@ export class StrategyService {
         const { sendEmail } = await import("../email/email.service");
         const content = email.html || email.text || "";
         await sendEmail({
+            from: email.from,
             to: strategy.forward_to,
             subject: `Fwd: ${email.subject}`,
             html: content,

--- a/server/modules/strategy/strategy.service.ts
+++ b/server/modules/strategy/strategy.service.ts
@@ -50,14 +50,15 @@ export class StrategyService {
      * Returns the first matching enabled strategy or null.
      */
     static async matchStrategy(from: string, to: string, subject: string): Promise<StrategyEntity | null> {
-        const strategies = await strategyRepository.find({ enabled: 1 });
-        for (const s of strategies) {
-            if (s.from_pattern && !matchGlob(from, s.from_pattern)) continue;
-            if (s.to_pattern && !matchGlob(to, s.to_pattern)) continue;
-            if (s.subject_pattern && !matchGlob(subject, s.subject_pattern)) continue;
-            return s;
-        }
-        return null;
+        let best: StrategyEntity | null = null;
+        await strategyRepository.findEach((s) => {
+            if (best) return;
+            if (s.from_pattern && !matchGlob(from, s.from_pattern)) return;
+            if (s.to_pattern && !matchGlob(to, s.to_pattern)) return;
+            if (s.subject_pattern && !matchGlob(subject, s.subject_pattern)) return;
+            best = s;
+        }, { where: { enabled: 1 } });
+        return best;
     }
 }
 

--- a/shared/modules/auth/auth.interface.ts
+++ b/shared/modules/auth/auth.interface.ts
@@ -127,10 +127,10 @@ export class AuthConfigRequest implements BaseRequest {
     }
 }
 
-export class AuthConfigResponse implements BaseResponse<{ allowed_domains: string[]; allowed_from_domains: string[] }> {
+export class AuthConfigResponse implements BaseResponse<{ allowed_domains: string[]; allowed_from_domains: string[]; allow_register: boolean }> {
     public success: boolean;
     public message: string;
-    public data: { allowed_domains: string[]; allowed_from_domains: string[] };
+    public data: { allowed_domains: string[]; allowed_from_domains: string[]; allow_register: boolean };
 
     constructor(origin: AuthConfigResponse) {
         this.success = origin.success;

--- a/shared/modules/auth/auth.interface.ts
+++ b/shared/modules/auth/auth.interface.ts
@@ -127,10 +127,10 @@ export class AuthConfigRequest implements BaseRequest {
     }
 }
 
-export class AuthConfigResponse implements BaseResponse<{ allowed_domains: string[] }> {
+export class AuthConfigResponse implements BaseResponse<{ allowed_domains: string[]; allowed_from_domains: string[] }> {
     public success: boolean;
     public message: string;
-    public data: { allowed_domains: string[] };
+    public data: { allowed_domains: string[]; allowed_from_domains: string[] };
 
     constructor(origin: AuthConfigResponse) {
         this.success = origin.success;


### PR DESCRIPTION
## Summary

A series of bug fixes and feature enhancements

### OOM Risk Elimination
- `safety.service.ts` — `isBlocked()` uses `findEach` streaming instead of loading all rules, reducing 3 arrays to 3 booleans
- `email.service.ts` — hot path `importFromFile()` uses `findFirst` single-record dedup check; cold path retains Set-based dedup
- `repository.ts` — `find()` now defaults to limit 1000 as a safety net

### Windows EPERM Fix
- `repository.ts` `update()`, `hardDelete()`, `atomicPatch()` reverted from stream+temp+rename to `readFileSync`+`writeFileSync`, avoiding Bun file handle not released before rename on Windows

### Domain Splitting & Multi-domain Resend
- Registration domains (`allowed_domains`) and sending domains (`allowed_from_domains`) fully separated
- Per-domain Resend API key matching (`resend_api_keys`, format: `domain1:key1,domain2:key2`)
- `resend_api_key` retained as default key for backward compatibility

### Registration Toggle
- New `allow_register` setting, defaults to disabled
- Frontend AuthPage dynamically loads config and hides registration entry when disabled
- Backend register endpoint checks the toggle

### Other
- `SendPage.tsx` now shows toast on send failure
- `webhttp.ts` catch block dispatches error events so callbacks receive failure notifications
- Removed password `console.log` from `auth.service.ts` and `initialize.ts`